### PR TITLE
some small improvements to sql backend support

### DIFF
--- a/js/OSM4Leaflet.ts
+++ b/js/OSM4Leaflet.ts
@@ -31,7 +31,11 @@ class OSM4Leaflet extends L.Layer {
   addData(data, onDone?: () => void) {
     setTimeout(() => {
       // 1. convert to GeoJSON
-      const geojson = (this.options.query_lang == 'SQL') ? data : osmtogeojson(data, {flatProperties: false});
+      const isGeoJSON =
+        typeof data === "object" && data?.type === "FeatureCollection";
+      const geojson = isGeoJSON
+        ? data
+        : osmtogeojson(data, {flatProperties: false});
       this._resultData = geojson;
       if (this.options.afterParse) this.options.afterParse();
       setTimeout(() => {

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -218,7 +218,7 @@ class IDE {
     abort() {
       if (typeof this.onAbort == "function") {
         this.addInfo("aborting");
-        this.onAbort(this.close);
+        this.onAbort(() => ide.waiter.close());
       }
     }
   })();

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -1026,17 +1026,21 @@ class IDE {
       // display stats
       if (settings.show_data_stats) {
         const stats = overpass.stats;
-        const stats_txt =
-          `<small>${i18n.t("data_stats.loaded")}</small>&nbsp;&ndash;&nbsp;` +
-          `${i18n.t("data_stats.nodes")}:&nbsp;${stats.data.nodes}, ${i18n.t(
-            "data_stats.ways"
-          )}:&nbsp;${stats.data.ways}, ${i18n.t(
-            "data_stats.relations"
-          )}:&nbsp;${stats.data.relations}${
-            stats.data.areas > 0
-              ? `, ${i18n.t("data_stats.areas")}:&nbsp;${stats.data.areas}`
-              : ""
-          }<br/>` +
+        let stats_txt = "";
+        if (stats.data !== undefined) {
+          stats_txt +=
+            `<small>${i18n.t("data_stats.loaded")}</small>&nbsp;&ndash;&nbsp;` +
+            `${i18n.t("data_stats.nodes")}:&nbsp;${stats.data.nodes}, ${i18n.t(
+              "data_stats.ways"
+            )}:&nbsp;${stats.data.ways}, ${i18n.t(
+              "data_stats.relations"
+            )}:&nbsp;${stats.data.relations}${
+              stats.data.areas > 0
+                ? `, ${i18n.t("data_stats.areas")}:&nbsp;${stats.data.areas}`
+                : ""
+            }<br/>`;
+        }
+        stats_txt +=
           `<small>${i18n.t(
             "data_stats.displayed"
           )}</small>&nbsp;&ndash;&nbsp;` +
@@ -1195,11 +1199,9 @@ class IDE {
     this.codeEditor.setValue(query);
   }
   getQueryLang() {
-    const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""))
-    if (q.match(/^</))
-      return "xml";
-    else if (q.match(/^select/i))
-      return "SQL";
+    const q = $.trim(this.getRawQuery().replace(/{{.*?}}/g, ""));
+    if (q.match(/^</)) return "xml";
+    else if (q.match(/^select/i)) return "SQL";
     else return "OverpassQL";
   }
   /* this is for repairing obvious mistakes in the query, such as missing recurse statements */
@@ -1536,11 +1538,13 @@ class IDE {
       location.pathname.match(/.*\//)[0]
     }`;
     const query_lang = this.getQueryLang();
-    const server = (this.data_source &&
+    const server =
+      this.data_source &&
       this.data_source.options.server &&
       ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-       this.data_source.mode == "overpass")) ? 
-          this.data_source.options.server : settings.server;
+        this.data_source.mode == "overpass")
+        ? this.data_source.options.server
+        : settings.server;
     let queryWithMapCSS = query;
     if (this.queryParser.hasStatement("style"))
       queryWithMapCSS += `{{style: ${this.queryParser.getStatement(
@@ -2722,11 +2726,13 @@ class IDE {
       }
     }
     const query_lang = this.getQueryLang();
-    const server = (this.data_source &&
+    const server =
+      this.data_source &&
       this.data_source.options.server &&
       ((query_lang == "SQL" && this.data_source.mode == "sql") ||
-       this.data_source.mode == "overpass")) ? 
-          this.data_source.options.server : settings.server;
+        this.data_source.mode == "overpass")
+        ? this.data_source.options.server
+        : settings.server;
 
     overpass.run_query(
       query,

--- a/js/ide.ts
+++ b/js/ide.ts
@@ -383,6 +383,25 @@ class IDE {
           }
         )
       );
+      CodeMirror.defineMode("sql+mustache", (config) =>
+        CodeMirror.multiplexingMode(
+          CodeMirror.multiplexingMode(
+            CodeMirror.getMode(config, "text/x-sql"),
+            {
+              open: "{{",
+              close: "}}",
+              mode: CodeMirror.getMode(config, "text/plain"),
+              delimStyle: "mustache"
+            }
+          ),
+          {
+            open: "{{style:",
+            close: "}}",
+            mode: CodeMirror.getMode(config, "text/css"),
+            delimStyle: "mustache"
+          }
+        )
+      );
       ide.codeEditor = CodeMirror.fromTextArea($("#editor textarea")[0], {
         //value: settings.code["overpass"],
         lineNumbers: true,
@@ -397,6 +416,12 @@ class IDE {
                 e.closeTagEnabled = true;
                 e.setOption("matchBrackets", false);
                 e.setOption("mode", "xml+mustache");
+              }
+            } else if (ide.getQueryLang() == "SQL") {
+              if (e.getOption("mode") != "sql+mustache") {
+                e.closeTagEnabled = false;
+                e.setOption("matchBrackets", true);
+                e.setOption("mode", "sql+mustache");
               }
             } else {
               if (e.getOption("mode") != "ql+mustache") {

--- a/js/index.ts
+++ b/js/index.ts
@@ -10,6 +10,7 @@ import "codemirror/mode/javascript/javascript";
 import "codemirror/mode/xml/xml";
 import "codemirror/mode/clike/clike";
 import "codemirror/mode/css/css";
+import "codemirror/mode/sql/sql";
 import "codemirror/lib/util/multiplex";
 import "codemirror/lib/util/closetag";
 

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -280,13 +280,15 @@ class Overpass {
                     continue;
                   feature.properties.tags[key] = feature.properties[key];
                 }
-                if (feature.properties.osm_id < 0) {
-                  feature.properties.type = "relation";
-                  feature.properties.id = -feature.properties.osm_id;
-                } else {
-                  feature.properties.type =
-                    feature.geometry.type === "Point" ? "node" : "way";
-                  feature.properties.id = feature.properties.osm_id;
+                if (feature.properties.osm_id) {
+                  if (feature.properties.osm_id < 0) {
+                    feature.properties.type = "relation";
+                    feature.properties.id = -feature.properties.osm_id;
+                  } else {
+                    feature.properties.type =
+                      feature.geometry.type === "Point" ? "node" : "way";
+                    feature.properties.id = feature.properties.osm_id;
+                  }
                 }
               });
             } else {

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -192,6 +192,9 @@ class Overpass {
                 (typeof data == "object" &&
                   data.remark &&
                   data.remark.length > 0);
+              is_error ||=
+                typeof data == "string" &&
+                data.indexOf("pq: syntax error") != -1;
               if (is_error) {
                 // this really looks like an error message, so lets open an additional modal error message
                 let errmsg = "?";

--- a/js/overpass.ts
+++ b/js/overpass.ts
@@ -6,6 +6,7 @@ import L_PopupIcon from "./PopupIcon"; // eslint-disable-line @typescript-eslint
 import L_OSM4Leaflet from "./OSM4Leaflet";
 import L_GeoJsonNoVanish from "./GeoJsonNoVanish";
 
+import ide from "./ide";
 import configs from "./configs";
 import settings from "./settings";
 import {htmlentities} from "./misc";
@@ -82,11 +83,12 @@ class Overpass {
     }
     overpass.fire(
       "onProgress",
-      "calling Overpass API interpreter",
+      `calling ${ide.getQueryLang() === "SQL" ? "SQL Server" : "Overpass API interpreter"}`,
       (callback) => {
         // kill the query on abort
         overpass.ajax_request.abort();
-        // try to abort queries via kill_my_queries
+        if (ide.getQueryLang() === "SQL") return callback();
+        // try to abort Overpass API queries via kill_my_queries
         $.get(`${server}kill_my_queries`)
           .done(callback)
           .fail(() => {

--- a/js/popup.ts
+++ b/js/popup.ts
@@ -26,8 +26,8 @@ export function featurePopupContent(feature: GeoJSON.Feature) {
       ` <a href="//www.openstreetmap.org/relation/${feature.properties.id}" target="_blank">${feature.properties.id}</a>` +
       ` <a href="//www.openstreetmap.org/edit?relation=${feature.properties.id}" target="_blank">✏</a>` +
       `</h4>`;
-  else
-    popup += `<h5 class="subtitle is-5">${feature.properties.type} #${feature.properties.id}</h5>`;
+  else if (feature.properties.id)
+    popup += `<h5 class="subtitle is-5">${feature.properties.type || ""} #${feature.properties.id}</h5>`;
   if (
     feature.properties &&
     feature.properties.tags &&


### PR DESCRIPTION
* use SQL syntax highlighting when SQL format is detected
* skip `kill_my_queries` when clicking on _abort_ for sql queries
* handle pgsql syntax errors -> show error dialog
* convert all "tag-like" properties to tags (e.g. to display in popup, use for mapcss)
* hide raw osm data stats if not applicable
* set osm type/id as inferred from osm_id property and geometry type
    * when `osm_id` is negative, osm type should be `relation`
    * when `geometry.type` is Point, osm type should be `node`
    * otherwise the osm type should be `way

note: the osm type/id guessing only works as long as the feature's geometry type does match the original osm element type, and would lead to false results if geometry operation like `ST_Centroid` are applied in the SQL query. :shrug: 